### PR TITLE
fix: deal with 'pt' unit suffix in svg width/height

### DIFF
--- a/src/main/java/de/vandermeer/svg2vector/applications/fh/converters/BatikLoader.java
+++ b/src/main/java/de/vandermeer/svg2vector/applications/fh/converters/BatikLoader.java
@@ -124,8 +124,8 @@ public class BatikLoader extends SV_DocumentLoader {
 			String width_str;
 			String height_str;
 			try{
-				width_str = elem.getAttribute("width").replaceAll("pt$", "");
-				height_str = elem.getAttribute("height").replaceAll("pt$", "");
+				width_str = elem.getAttribute("width").replaceAll("[A-Za-z]$", "");
+				height_str = elem.getAttribute("height").replaceAll("[A-Za-z]$", "");
 				this.size.setSize(Double.valueOf(width_str), Double.valueOf(height_str));
 				elem.setAttribute("width", width_str);
 				elem.setAttribute("height", height_str);

--- a/src/main/java/de/vandermeer/svg2vector/applications/fh/converters/BatikLoader.java
+++ b/src/main/java/de/vandermeer/svg2vector/applications/fh/converters/BatikLoader.java
@@ -121,8 +121,14 @@ public class BatikLoader extends SV_DocumentLoader {
 
 			Element elem = this.svgDocument.getDocumentElement();
 			this.size = new Dimension();
+			String width_str;
+			String height_str;
 			try{
-				this.size.setSize(Double.valueOf(elem.getAttribute("width")), Double.valueOf(elem.getAttribute("height")));
+				width_str = elem.getAttribute("width").replaceAll("pt$", "");
+				height_str = elem.getAttribute("height").replaceAll("pt$", "");
+				this.size.setSize(Double.valueOf(width_str), Double.valueOf(height_str));
+				elem.setAttribute("width", width_str);
+				elem.setAttribute("height", height_str);
 			}
 			catch(Exception ex){
 				this.bridgeContext = null;


### PR DESCRIPTION
Some `.svg` files have:
```xml
<svg width="100pt" height="50pt">
```

This PR removes the 'pt' suffix from both elements, which otherwise would cause `svg2vector` to fail.

matplotlib's `savefig('fig.svg')` is an example of software that generates svg files that svg2vector can't load.